### PR TITLE
Fix Google user creation and cleanup

### DIFF
--- a/api/controllers/groupController.js
+++ b/api/controllers/groupController.js
@@ -1,4 +1,3 @@
-import e from 'express';
 import groupService from '../services/groupService.js';
 import userService from '../services/userService.js';
 

--- a/api/dataAccess/userDAO.js
+++ b/api/dataAccess/userDAO.js
@@ -5,12 +5,12 @@ const findByEmail = async (email) => {
   return await User.findOne({ email });
 };
 
-const createFromGoogle = async ({ email, name, picture, sub, locale }) => {
+const createFromGoogle = async ({ email, name, avatar, googleId, locale }) => {
   const user = new User({
     email,
     name,
-    avatar: picture,
-    googleId: sub,
+    avatar,
+    googleId,
     locale: locale || 'en',
     timezone: 'UTC',       // podrías cambiar esto con la hora del cliente si se conoce
     lastLogin: new Date(),

--- a/api/tests/unit/dataAccess/userDAO.test.js
+++ b/api/tests/unit/dataAccess/userDAO.test.js
@@ -24,8 +24,8 @@ describe('userDAO', () => {
       const googleUser = {
         name: 'Pablo',
         email: 'pablo@example.com',
-        picture: 'url-imagen',
-        uid: 'google-uid-123'
+        avatar: 'url-imagen',
+        googleId: 'google-uid-123'
       };
       const mockUser = { _id: 'u1', ...googleUser };
       sinon.stub(User.prototype, 'save').resolves(mockUser);


### PR DESCRIPTION
## Summary
- fix `createFromGoogle` to use avatar and googleId
- update related unit test
- remove unused import from `groupController`

## Testing
- `npm test --silent` *(fails: cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68404ab93dac83318af32fe7cd8b3b7e