### PR TITLE
Implement group & item navigation

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
 
     defaultConfig {
         applicationId = "com.thaya.shop_family"
-        minSdk = 24
+        minSdk = 33
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MaterialComponents.DayNight.DarkActionBar"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:enableOnBackInvokedCallback="true">
 
         <activity android:name=".ui.MainActivity"
             android:exported="true">

--- a/android/app/src/main/java/com/thaya/shop_family/models/Group.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/models/Group.kt
@@ -1,11 +1,11 @@
 package com.thaya.shop_family.models
 
-import com.thaya.shop_family.models.UserGroup
+import com.google.gson.annotations.SerializedName
 import java.io.Serializable
 
 data class Group(
-    val _id: String,
+    @SerializedName("_id") val id: String,
     val name: String,
-    val members: List<UserGroup>,
+    val members: List<Member>,
     val createdAt: String
 ) : Serializable

--- a/android/app/src/main/java/com/thaya/shop_family/models/Item.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/models/Item.kt
@@ -1,9 +1,10 @@
 package com.thaya.shop_family.models
 
+import com.google.gson.annotations.SerializedName
 import java.io.Serializable
 
 data class Item(
-    val _id: String,
+    @SerializedName("_id") val id: String,
     val name: String,
     val quantity: String,
     val isPurchased: Boolean,

--- a/android/app/src/main/java/com/thaya/shop_family/models/Member.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/models/Member.kt
@@ -1,9 +1,8 @@
 package com.thaya.shop_family.models
 
-import com.thaya.shop_family.models.User
 import java.io.Serializable
 
-data class UserGroup(
-    val user: User,
+data class Member(
+    val user: String,
     val role: String
 ) : Serializable

--- a/android/app/src/main/java/com/thaya/shop_family/models/User.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/models/User.kt
@@ -1,9 +1,10 @@
 package com.thaya.shop_family.models
 
+import com.google.gson.annotations.SerializedName
 import java.io.Serializable
 
 data class User(
-    val _id: String,
+    @SerializedName("_id") val id: String,
     val name: String,
     val email: String,
     val googleId: String,

--- a/android/app/src/main/java/com/thaya/shop_family/models/UserGroup.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/models/UserGroup.kt
@@ -1,8 +1,9 @@
 package com.thaya.shop_family.models
 
 import com.thaya.shop_family.models.User
+import java.io.Serializable
 
 data class UserGroup(
     val user: User,
     val role: String
-)
+) : Serializable

--- a/android/app/src/main/java/com/thaya/shop_family/models/UserProfile.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/models/UserProfile.kt
@@ -1,8 +1,0 @@
-package com.thaya.shop_family.models
-
-import com.thaya.shop_family.models.User
-
-data class UserProfile(
-    val token: String,
-    val user: User
-)

--- a/android/app/src/main/java/com/thaya/shop_family/models/group.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/models/group.kt
@@ -1,10 +1,11 @@
 package com.thaya.shop_family.models
 
 import com.thaya.shop_family.models.UserGroup
+import java.io.Serializable
 
 data class Group(
     val _id: String,
     val name: String,
     val members: List<UserGroup>,
     val createdAt: String
-)
+) : Serializable

--- a/android/app/src/main/java/com/thaya/shop_family/models/item.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/models/item.kt
@@ -1,5 +1,7 @@
 package com.thaya.shop_family.models
 
+import java.io.Serializable
+
 data class Item(
     val _id: String,
     val name: String,
@@ -8,4 +10,4 @@ data class Item(
     val groupId: String,
     val addedBy: String,
     val createdAt: String
-)
+) : Serializable

--- a/android/app/src/main/java/com/thaya/shop_family/models/user.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/models/user.kt
@@ -1,5 +1,7 @@
 package com.thaya.shop_family.models
 
+import java.io.Serializable
+
 data class User(
     val _id: String,
     val name: String,
@@ -13,4 +15,4 @@ data class User(
     val lastLogout: String,
     val active: Boolean,
     val createdAt: String
-)
+) : Serializable

--- a/android/app/src/main/java/com/thaya/shop_family/network/GroupService.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/network/GroupService.kt
@@ -1,8 +1,6 @@
 package com.thaya.shop_family.network
 
 import com.thaya.shop_family.models.Group
-import com.thaya.shop_family.models.Item
-import com.thaya.shop_family.models.UserGroup
 import retrofit2.Response
 import retrofit2.http.*
 

--- a/android/app/src/main/java/com/thaya/shop_family/network/GroupService.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/network/GroupService.kt
@@ -1,0 +1,21 @@
+package com.thaya.shop_family.network
+
+import com.thaya.shop_family.models.Group
+import com.thaya.shop_family.models.Item
+import com.thaya.shop_family.models.UserGroup
+import retrofit2.Response
+import retrofit2.http.*
+
+interface GroupService {
+    @GET("groups")
+    suspend fun getGroups(): Response<List<Group>>
+
+    @POST("groups/{groupId}/add-member")
+    suspend fun addMember(
+        @Path("groupId") groupId: String,
+        @Body body: Map<String, String>
+    ): Response<Group>
+
+    @DELETE("groups/{id}")
+    suspend fun deleteGroup(@Path("id") id: String): Response<Void>
+}

--- a/android/app/src/main/java/com/thaya/shop_family/network/ItemService.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/network/ItemService.kt
@@ -1,0 +1,16 @@
+package com.thaya.shop_family.network
+
+import com.thaya.shop_family.models.Item
+import retrofit2.Response
+import retrofit2.http.*
+
+interface ItemService {
+    @GET("items/{groupId}")
+    suspend fun getItems(@Path("groupId") groupId: String): Response<List<Item>>
+
+    @POST("items")
+    suspend fun addItem(@Body body: Map<String, String>): Response<Item>
+
+    @DELETE("items/{itemId}")
+    suspend fun deleteItem(@Path("itemId") itemId: String): Response<Void>
+}

--- a/android/app/src/main/java/com/thaya/shop_family/network/RetrofitClient.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/network/RetrofitClient.kt
@@ -29,14 +29,22 @@ object RetrofitClient {
             .create(AuthService::class.java)
     }
 
-    val userService: UserService by lazy {
-        val retrofit = Retrofit.Builder()
-            .baseUrl(BASE_URL)
-            .client(client)
-            .addConverterFactory(GsonConverterFactory.create())
-            .build();
+    private fun authRetrofit(): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
 
-        retrofit.create(UserService::class.java)
+    val userService: UserService by lazy {
+        authRetrofit().create(UserService::class.java)
+    }
+
+    val groupService: GroupService by lazy {
+        authRetrofit().create(GroupService::class.java)
+    }
+
+    val itemService: ItemService by lazy {
+        authRetrofit().create(ItemService::class.java)
     }
 
 

--- a/android/app/src/main/java/com/thaya/shop_family/ui/HomeActivity.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/HomeActivity.kt
@@ -40,6 +40,8 @@ class HomeActivity : AppCompatActivity() {
 
         if (sessionManager.fetchAuthToken() == null) {
             navigateToLogin()
+        } else {
+            UserSession.jwtToken = sessionManager.fetchAuthToken()
         }
         // Verificar si el usuario ya está autenticado
 //        if (UserSession.jwtToken != null) {

--- a/android/app/src/main/java/com/thaya/shop_family/ui/LoginActivity.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/LoginActivity.kt
@@ -126,7 +126,7 @@ class LoginActivity : AppCompatActivity() {
                     Log.i("BACKEND", "Token backend: ${result?.token}")
                     Log.i("BACKEND", "Usuario: ${result?.user?.name}, ${result?.user?.email}")
                     UserSession.jwtToken = result?.token;
-                    UserSession.userId = result?.user?._id;
+                    UserSession.userId = result?.user?.id;
                     onSuccess();
                 } else {
                     Log.e("BACKEND", "Error en respuesta: ${response.code()}")

--- a/android/app/src/main/java/com/thaya/shop_family/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupActionBarWithNavController
 import com.thaya.shop_family.R
+import com.thaya.shop_family.session.UserSession
 import com.thaya.shop_family.utils.SessionManager
 
 class MainActivity : AppCompatActivity() {
@@ -18,6 +19,7 @@ class MainActivity : AppCompatActivity() {
         val sessionManager = SessionManager(this)
         val graph = navController.navInflater.inflate(R.navigation.nav_graph)
         if (sessionManager.fetchAuthToken() != null) {
+            UserSession.jwtToken = sessionManager.fetchAuthToken()
             graph.setStartDestination(R.id.homeFragment)
         } else {
             graph.setStartDestination(R.id.loginFragment)

--- a/android/app/src/main/java/com/thaya/shop_family/ui/adapters/GroupAdapter.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/adapters/GroupAdapter.kt
@@ -1,0 +1,52 @@
+package com.thaya.shop_family.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.thaya.shop_family.databinding.ItemGroupBinding
+import com.thaya.shop_family.models.Group
+import com.thaya.shop_family.session.UserSession
+
+class GroupAdapter(
+    private val onGroupClick: (Group) -> Unit,
+    private val onAddUser: (Group) -> Unit,
+    private val onAddItem: (Group) -> Unit,
+    private val onDelete: (Group) -> Unit
+) : RecyclerView.Adapter<GroupAdapter.GroupViewHolder>() {
+
+    private var groups: List<Group> = emptyList()
+
+    inner class GroupViewHolder(val binding: ItemGroupBinding) : RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GroupViewHolder {
+        val binding = ItemGroupBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return GroupViewHolder(binding)
+    }
+
+    override fun getItemCount(): Int = groups.size
+
+    override fun onBindViewHolder(holder: GroupViewHolder, position: Int) {
+        val group = groups[position]
+        holder.binding.groupNameTextView.text = group.name
+        holder.binding.root.setOnClickListener { onGroupClick(group) }
+        holder.binding.addUserButton.setOnClickListener { onAddUser(group) }
+        holder.binding.addItemButton.setOnClickListener { onAddItem(group) }
+        if (isAdmin(group)) {
+            holder.binding.deleteGroupButton.visibility = View.VISIBLE
+            holder.binding.deleteGroupButton.setOnClickListener { onDelete(group) }
+        } else {
+            holder.binding.deleteGroupButton.visibility = View.GONE
+        }
+    }
+
+    fun submitList(list: List<Group>) {
+        groups = list
+        notifyDataSetChanged()
+    }
+
+    private fun isAdmin(group: Group): Boolean {
+        val id = UserSession.userId
+        return group.members.any { it.user._id == id && it.role == "admin" }
+    }
+}

--- a/android/app/src/main/java/com/thaya/shop_family/ui/adapters/GroupAdapter.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/adapters/GroupAdapter.kt
@@ -47,6 +47,6 @@ class GroupAdapter(
 
     private fun isAdmin(group: Group): Boolean {
         val id = UserSession.userId
-        return group.members.any { it.user._id == id && it.role == "admin" }
+        return group.members.any { it.user == id && it.role == "admin" }
     }
 }

--- a/android/app/src/main/java/com/thaya/shop_family/ui/adapters/ItemAdapter.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/adapters/ItemAdapter.kt
@@ -1,0 +1,35 @@
+package com.thaya.shop_family.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.thaya.shop_family.databinding.ItemItemBinding
+import com.thaya.shop_family.models.Item
+
+class ItemAdapter(
+    private val onDelete: (Item) -> Unit
+) : RecyclerView.Adapter<ItemAdapter.ItemViewHolder>() {
+
+    private var items: List<Item> = emptyList()
+
+    inner class ItemViewHolder(val binding: ItemItemBinding) : RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
+        val binding = ItemItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ItemViewHolder(binding)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: ItemViewHolder, position: Int) {
+        val item = items[position]
+        holder.binding.itemNameTextView.text = item.name
+        holder.binding.itemQuantityTextView.text = item.quantity
+        holder.binding.deleteItemButton.setOnClickListener { onDelete(item) }
+    }
+
+    fun submitList(list: List<Item>) {
+        items = list
+        notifyDataSetChanged()
+    }
+}

--- a/android/app/src/main/java/com/thaya/shop_family/ui/adapters/UserAdapter.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/adapters/UserAdapter.kt
@@ -4,11 +4,11 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.thaya.shop_family.databinding.ItemUserBinding
-import com.thaya.shop_family.models.UserGroup
+import com.thaya.shop_family.models.Member
 
 class UserAdapter : RecyclerView.Adapter<UserAdapter.UserViewHolder>() {
 
-    private var members: List<UserGroup> = emptyList()
+    private var members: List<Member> = emptyList()
 
     inner class UserViewHolder(val binding: ItemUserBinding) : RecyclerView.ViewHolder(binding.root)
 
@@ -21,10 +21,10 @@ class UserAdapter : RecyclerView.Adapter<UserAdapter.UserViewHolder>() {
 
     override fun onBindViewHolder(holder: UserViewHolder, position: Int) {
         val member = members[position]
-        holder.binding.userNameTextView.text = member.user.name
+        //holder.binding.userNameTextView.text = member.user.name
     }
 
-    fun submitList(list: List<UserGroup>) {
+    fun submitList(list: List<Member>) {
         members = list
         notifyDataSetChanged()
     }

--- a/android/app/src/main/java/com/thaya/shop_family/ui/adapters/UserAdapter.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/adapters/UserAdapter.kt
@@ -1,0 +1,31 @@
+package com.thaya.shop_family.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.thaya.shop_family.databinding.ItemUserBinding
+import com.thaya.shop_family.models.UserGroup
+
+class UserAdapter : RecyclerView.Adapter<UserAdapter.UserViewHolder>() {
+
+    private var members: List<UserGroup> = emptyList()
+
+    inner class UserViewHolder(val binding: ItemUserBinding) : RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserViewHolder {
+        val binding = ItemUserBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return UserViewHolder(binding)
+    }
+
+    override fun getItemCount(): Int = members.size
+
+    override fun onBindViewHolder(holder: UserViewHolder, position: Int) {
+        val member = members[position]
+        holder.binding.userNameTextView.text = member.user.name
+    }
+
+    fun submitList(list: List<UserGroup>) {
+        members = list
+        notifyDataSetChanged()
+    }
+}

--- a/android/app/src/main/java/com/thaya/shop_family/ui/fragments/GroupListFragment.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/fragments/GroupListFragment.kt
@@ -1,0 +1,68 @@
+package com.thaya.shop_family.ui.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.thaya.shop_family.R
+import com.thaya.shop_family.databinding.FragmentGroupListBinding
+import com.thaya.shop_family.models.Group
+import com.thaya.shop_family.network.RetrofitClient
+import com.thaya.shop_family.ui.adapters.GroupAdapter
+import kotlinx.coroutines.launch
+
+class GroupListFragment : Fragment() {
+
+    private var _binding: FragmentGroupListBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var adapter: GroupAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentGroupListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        adapter = GroupAdapter(
+            onGroupClick = { group ->
+                val bundle = Bundle().apply { putSerializable("group", group) }
+                findNavController().navigate(R.id.action_groupListFragment_to_itemListFragment, bundle)
+            },
+            onAddUser = { Toast.makeText(requireContext(), "Agregar usuario", Toast.LENGTH_SHORT).show() },
+            onAddItem = { Toast.makeText(requireContext(), "Agregar item", Toast.LENGTH_SHORT).show() },
+            onDelete = { Toast.makeText(requireContext(), "Eliminar grupo", Toast.LENGTH_SHORT).show() }
+        )
+        binding.groupsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.groupsRecyclerView.adapter = adapter
+        lifecycleScope.launch { loadGroups() }
+    }
+
+    private suspend fun loadGroups() {
+        try {
+            val response = RetrofitClient.groupService.getGroups()
+            if (response.isSuccessful) {
+                adapter.submitList(response.body() ?: emptyList())
+            } else {
+                Toast.makeText(requireContext(), R.string.error_loading, Toast.LENGTH_SHORT).show()
+            }
+        } catch (e: Exception) {
+            Toast.makeText(requireContext(), R.string.network_error, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/android/app/src/main/java/com/thaya/shop_family/ui/fragments/GroupListFragment.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/fragments/GroupListFragment.kt
@@ -1,6 +1,7 @@
 package com.thaya.shop_family.ui.fragments
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -57,6 +58,7 @@ class GroupListFragment : Fragment() {
                 Toast.makeText(requireContext(), R.string.error_loading, Toast.LENGTH_SHORT).show()
             }
         } catch (e: Exception) {
+            Log.e("loadGroups", "getGroups - failed", e)
             Toast.makeText(requireContext(), R.string.network_error, Toast.LENGTH_SHORT).show()
         }
     }

--- a/android/app/src/main/java/com/thaya/shop_family/ui/fragments/GroupUsersFragment.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/fragments/GroupUsersFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.thaya.shop_family.databinding.FragmentGroupUsersBinding
-import com.thaya.shop_family.models.UserGroup
+import com.thaya.shop_family.models.Member
 import com.thaya.shop_family.ui.adapters.UserAdapter
 
 class GroupUsersFragment : Fragment() {
@@ -26,7 +26,8 @@ class GroupUsersFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val members = requireArguments().getSerializable("members") as ArrayList<UserGroup>? ?: arrayListOf()
+        val members = requireArguments().getSerializable("members", ArrayList::class.java) as? ArrayList<Member> ?: arrayListOf()
+
         val adapter = UserAdapter()
         binding.usersRecyclerView.layoutManager = LinearLayoutManager(requireContext())
         binding.usersRecyclerView.adapter = adapter

--- a/android/app/src/main/java/com/thaya/shop_family/ui/fragments/GroupUsersFragment.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/fragments/GroupUsersFragment.kt
@@ -1,0 +1,40 @@
+package com.thaya.shop_family.ui.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.thaya.shop_family.databinding.FragmentGroupUsersBinding
+import com.thaya.shop_family.models.UserGroup
+import com.thaya.shop_family.ui.adapters.UserAdapter
+
+class GroupUsersFragment : Fragment() {
+
+    private var _binding: FragmentGroupUsersBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentGroupUsersBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val members = requireArguments().getSerializable("members") as ArrayList<UserGroup>? ?: arrayListOf()
+        val adapter = UserAdapter()
+        binding.usersRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.usersRecyclerView.adapter = adapter
+        adapter.submitList(members)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/android/app/src/main/java/com/thaya/shop_family/ui/fragments/HomeFragment.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/fragments/HomeFragment.kt
@@ -61,6 +61,10 @@ class HomeFragment : Fragment() {
                     lifecycleScope.launch { logout() }
                     true
                 }
+                R.id.nav_list -> {
+                    findNavController().navigate(R.id.action_homeFragment_to_groupListFragment)
+                    true
+                }
                 else -> true
             }
         }

--- a/android/app/src/main/java/com/thaya/shop_family/ui/fragments/HomeFragment.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/fragments/HomeFragment.kt
@@ -80,7 +80,7 @@ class HomeFragment : Fragment() {
                 val db = AppDatabase.get(requireContext())
                 db.userProfileDao().saveProfile(
                     com.thaya.shop_family.data.UserProfileEntity(
-                        id = profile?._id ?: "0",
+                        id = profile?.id ?: "0",
                         name = profile?.name.toString(),
                         email = profile?.email.toString(),
                         avatar = profile?.avatar

--- a/android/app/src/main/java/com/thaya/shop_family/ui/fragments/ItemListFragment.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/fragments/ItemListFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.thaya.shop_family.R
 import com.thaya.shop_family.databinding.FragmentItemListBinding
 import com.thaya.shop_family.models.Group
+import com.thaya.shop_family.models.Member
 import com.thaya.shop_family.network.RetrofitClient
 import com.thaya.shop_family.ui.adapters.ItemAdapter
 import kotlinx.coroutines.launch
@@ -37,6 +38,8 @@ class ItemListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         group = requireArguments().getSerializable("group") as Group
+        //group = requireArguments().getSerializable("group", Class::class.java) as Group;
+
         adapter = ItemAdapter { Toast.makeText(requireContext(), "Eliminar producto", Toast.LENGTH_SHORT).show() }
         binding.itemsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
         binding.itemsRecyclerView.adapter = adapter
@@ -53,7 +56,7 @@ class ItemListFragment : Fragment() {
 
     private suspend fun loadItems() {
         try {
-            val response = RetrofitClient.itemService.getItems(group._id)
+            val response = RetrofitClient.itemService.getItems(group.id)
             if (response.isSuccessful) {
                 adapter.submitList(response.body() ?: emptyList())
             } else {

--- a/android/app/src/main/java/com/thaya/shop_family/ui/fragments/ItemListFragment.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/fragments/ItemListFragment.kt
@@ -1,0 +1,71 @@
+package com.thaya.shop_family.ui.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.thaya.shop_family.R
+import com.thaya.shop_family.databinding.FragmentItemListBinding
+import com.thaya.shop_family.models.Group
+import com.thaya.shop_family.network.RetrofitClient
+import com.thaya.shop_family.ui.adapters.ItemAdapter
+import kotlinx.coroutines.launch
+
+class ItemListFragment : Fragment() {
+
+    private var _binding: FragmentItemListBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var adapter: ItemAdapter
+    private lateinit var group: Group
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentItemListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        group = requireArguments().getSerializable("group") as Group
+        adapter = ItemAdapter { Toast.makeText(requireContext(), "Eliminar producto", Toast.LENGTH_SHORT).show() }
+        binding.itemsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.itemsRecyclerView.adapter = adapter
+        binding.addItemFab.setOnClickListener {
+            Toast.makeText(requireContext(), "Agregar item", Toast.LENGTH_SHORT).show()
+        }
+        binding.membersButton.text = getString(R.string.members_count, group.members.size)
+        binding.membersButton.setOnClickListener {
+            val bundle = bundleOf("members" to ArrayList(group.members))
+            findNavController().navigate(R.id.action_itemListFragment_to_groupUsersFragment, bundle)
+        }
+        lifecycleScope.launch { loadItems() }
+    }
+
+    private suspend fun loadItems() {
+        try {
+            val response = RetrofitClient.itemService.getItems(group._id)
+            if (response.isSuccessful) {
+                adapter.submitList(response.body() ?: emptyList())
+            } else {
+                Toast.makeText(requireContext(), R.string.error_loading, Toast.LENGTH_SHORT).show()
+            }
+        } catch (e: Exception) {
+            Toast.makeText(requireContext(), R.string.network_error, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/android/app/src/main/java/com/thaya/shop_family/ui/fragments/LoginFragment.kt
+++ b/android/app/src/main/java/com/thaya/shop_family/ui/fragments/LoginFragment.kt
@@ -116,11 +116,11 @@ class LoginFragment : Fragment() {
                 val profile = response.body();
                 val user = profile?.user;
                 UserSession.jwtToken = profile?.token
-                UserSession.userId = user?._id
+                UserSession.userId = user?.id
                 val db = AppDatabase.get(requireContext())
                 db.userProfileDao().saveProfile(
                     UserProfileEntity(
-                        id = user?._id ?: "0",
+                        id = user?.id ?: "0",
                         name = user?.name.toString(),
                         email = user?.email.toString(),
                         avatar = user?.avatar

--- a/android/app/src/main/res/layout/fragment_group_list.xml
+++ b/android/app/src/main/res/layout/fragment_group_list.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/groupsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_group_users.xml
+++ b/android/app/src/main/res/layout/fragment_group_users.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/usersRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_item_list.xml
+++ b/android/app/src/main/res/layout/fragment_item_list.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <Button
+        android:id="@+id/membersButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Miembros" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/itemsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/addItemFab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@android:drawable/ic_input_add"
+        android:layout_gravity="end"
+        android:layout_margin="16dp" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_group.xml
+++ b/android/app/src/main/res/layout/item_group.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp"
+    android:gravity="center_vertical">
+
+    <TextView
+        android:id="@+id/groupNameTextView"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:textSize="16sp" />
+
+    <ImageButton
+        android:id="@+id/addUserButton"
+        android:src="@android:drawable/ic_menu_add"
+        android:contentDescription="Agregar usuario"
+        android:layout_width="40dp"
+        android:layout_height="40dp" />
+
+    <ImageButton
+        android:id="@+id/addItemButton"
+        android:src="@android:drawable/ic_input_add"
+        android:contentDescription="Agregar item"
+        android:layout_width="40dp"
+        android:layout_height="40dp" />
+
+    <ImageButton
+        android:id="@+id/deleteGroupButton"
+        android:src="@android:drawable/ic_menu_delete"
+        android:contentDescription="Eliminar"
+        android:layout_width="40dp"
+        android:layout_height="40dp" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_item.xml
+++ b/android/app/src/main/res/layout/item_item.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_weight="1">
+        <TextView
+            android:id="@+id/itemNameTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"/>
+        <TextView
+            android:id="@+id/itemQuantityTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+    </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/deleteItemButton"
+        android:src="@android:drawable/ic_menu_delete"
+        android:contentDescription="Eliminar"
+        android:layout_width="40dp"
+        android:layout_height="40dp" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_user.xml
+++ b/android/app/src/main/res/layout/item_user.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/userNameTextView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp"
+    android:textSize="16sp"/>

--- a/android/app/src/main/res/navigation/nav_graph.xml
+++ b/android/app/src/main/res/navigation/nav_graph.xml
@@ -20,5 +20,31 @@
             android:id="@+id/action_homeFragment_to_loginFragment"
             android:name="com.thaya.shop_family.ui.fragments.action_homeFragment_to_loginFragment"
             app:destination="@id/loginFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_groupListFragment"
+            app:destination="@id/groupListFragment" />
     </fragment>
+
+    <fragment
+        android:id="@+id/groupListFragment"
+        android:name="com.thaya.shop_family.ui.fragments.GroupListFragment"
+        android:label="groups">
+        <action
+            android:id="@+id/action_groupListFragment_to_itemListFragment"
+            app:destination="@id/itemListFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/itemListFragment"
+        android:name="com.thaya.shop_family.ui.fragments.ItemListFragment"
+        android:label="items">
+        <action
+            android:id="@+id/action_itemListFragment_to_groupUsersFragment"
+            app:destination="@id/groupUsersFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/groupUsersFragment"
+        android:name="com.thaya.shop_family.ui.fragments.GroupUsersFragment"
+        android:label="users" />
 </navigation>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">shop-family</string>
+    <string name="error_loading">Error al cargar datos</string>
+    <string name="network_error">Fallo en la red</string>
+    <string name="members_count">Usuarios (%1$d)</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement navigation for groups and items
- add GroupService and ItemService API clients
- create adapters and fragments for groups, items and group members
- wire bottom navigation to open group list

## Testing
- `./gradlew -q tasks` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a00ed95e08331a406034bb19ebdb8